### PR TITLE
Fix: inconsistent use of caml_stat_* functions

### DIFF
--- a/src/libssh_stubs.c
+++ b/src/libssh_stubs.c
@@ -153,7 +153,7 @@ CAMLprim value libssh_ml_ssh_exec(value command_val, value sess_val)
 
   struct result this_result = exec_remote_command(command, this_sess);
   output_val = caml_copy_string(this_result.output);
-  free(this_result.output);
+  caml_stat_free(this_result.output);
   CAMLreturn(output_val);
 }
 
@@ -203,8 +203,8 @@ CAMLprim value libssh_ml_ssh_connect(value opts, value sess_val)
 
   check_result(ssh_connect(this_sess), this_sess);
   verify_server(this_sess);
-  free(hostname);
-  free(username);
+  caml_stat_free(hostname);
+  caml_stat_free(username);
   switch (auth) {
   case 0:
     check_result(ssh_userauth_publickey_auto(this_sess, NULL, NULL), this_sess);
@@ -236,7 +236,7 @@ CAMLprim value libssh_ml_remote_shell(value produce, value consume, value sess_v
   struct result r = exec_remote_command(copied, this_sess);
 
   caml_callback(consume, caml_copy_string(r.output));
-  free(copied);
+  caml_stat_free(copied);
   CAMLreturn(Val_unit);
 }
 


### PR DESCRIPTION
One more patch in the "inconsistencies" series. I made it separate from the "leak" patch. That's all for your packages! 🐪 + 🍷 = 🐫

> Hello. I'm doing a large-scale study of C stub sources on OPAM.
> 
> Your library makes use of the undocumented `caml_stat_*` functions, which currently are thin wrappers around `malloc`, `realloc`, and `free` from the C standard library. In future, the implementation of these functions [may change](https://github.com/ocaml/ocaml/pull/71), making them incompatible with `malloc` and breaking the code that abused the old undocumented semantics.
> 
> Regardless of whether the change of semantics will happen or not, being consistent about such matters should be considered good style.
